### PR TITLE
Fix typos in solver docstrings (both CVODE and IDA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: ci
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ junit.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 
 # Translations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ None.
 None.
 
 ### Chores
+- Fix typos in solver docstrings, use global coverage ignores in `pyproject.toml` ([#55](https://github.com/NatLabRockies/scikit-sundae/pull/55))
 - Move to using `ruff` for linting and start tracking `Cython` addition issue ([#45](https://github.com/NatLabRockies/scikit-sundae/pull/45))
 - Make GitHub hyperlinks reference new org name `NREL` -> `NatLabRockies` ([#42](https://github.com/NatLabRockies/scikit-sundae/pull/42))
 - Allow single backticks for sphinx inline code (`default_role = 'literal'`) ([#40](https://github.com/NatLabRockies/scikit-sundae/pull/40))

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-<!-- <img alt='Logo' style='width: 75%; min-width: 250px; max-width: 500px;'
- src='https://github.com/NatLabRockies/scikit-sundae/blob/main/images/readme_logo.png?raw=true'/> -->
+# scikit-SUNDAE
 
- # scikit-SUNDAE
-
-[![ci](https://github.com/NatLabRockies/scikit-sundae/actions/workflows/ci.yml/badge.svg)](https://github.com/NatLabRockies/scikit-sundae/actions/workflows/ci.yml) &nbsp;
+[![ci-tests](https://github.com/NatLabRockies/scikit-sundae/actions/workflows/ci.yml/badge.svg)](https://github.com/NatLabRockies/scikit-sundae/actions/workflows/ci.yml) &nbsp;
 [![license](https://img.shields.io/badge/license-BSD--3-blue.svg)](https://github.com/NatLabRockies/scikit-sundae/blob/main/LICENSE) &nbsp;
 ![coverage](https://github.com/NatLabRockies/scikit-sundae/blob/main/images/coverage.svg?raw=true) <br>
 [![conda](https://img.shields.io/conda/vn/conda-forge/scikit-sundae)](https://anaconda.org/channels/conda-forge/packages/scikit-sundae/overview) &nbsp;

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -106,7 +106,7 @@ In all cases where you are trying to install from the source distribution, you s
 ====================== ==============================
 scikit-SUNDAE Version  Supported SUNDIALS Version(s)
 ====================== ==============================
-1.2.x [dev]             >=7.6, <7.8
+1.2.x [dev]             >=7.6, <7.9
 1.1.x                   >=7.3, <7.6
 1.0.x                   >=7.0, <7.3
 ====================== ==============================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ where = ["src"]
 line-length = 80
 exclude = ["build", "docs", "images", "reports", "C_programs"]
 
+[tool.ruff.format]
+quote-style = "preserve"
+
 [tool.ruff.lint]
 preview = true
 select = [
@@ -68,6 +71,12 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["D"]
+
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "if TYPE_CHECKING",
+]
 
 [project.optional-dependencies]
 docs = [

--- a/src/sksundae/__init__.py
+++ b/src/sksundae/__init__.py
@@ -53,12 +53,12 @@ distributed as well (e.g., SuperLU_MT, OpenBLAS, and LAPACK).
 
 """
 
-from ._cy_common import SUNDIALS_VERSION
-
 from . import ida
 from . import utils
 from . import cvode
 from . import jacband
+
+from ._cy_common import SUNDIALS_VERSION
 
 __all__ = ['ida', 'utils', 'cvode', 'jacband', 'SUNDIALS_VERSION']
 

--- a/src/sksundae/cvode/__init__.py
+++ b/src/sksundae/cvode/__init__.py
@@ -5,9 +5,9 @@ with support for direct and iterative linear solvers, root finding, and more.
 
 """
 
-from ._solver import CVODE, CVODEResult
 from ._precond import CVODEPrecond
 from ._jactimes import CVODEJacTimes
+from ._solver import CVODE, CVODEResult
 
 __all__ = [
     'CVODE',

--- a/src/sksundae/cvode/_jactimes.py
+++ b/src/sksundae/cvode/_jactimes.py
@@ -1,6 +1,5 @@
-# cvode._jactimes.py
-
 from __future__ import annotations
+
 from typing import Callable
 
 

--- a/src/sksundae/cvode/_precond.py
+++ b/src/sksundae/cvode/_precond.py
@@ -1,6 +1,5 @@
-# cvode._precond.py
-
 from __future__ import annotations
+
 from typing import Callable
 
 
@@ -9,8 +8,9 @@ class CVODEPrecond:
 
     __slots__ = ('setupfn', 'solvefn', 'side', '_prectype')
 
-    def __init__(self, setupfn: Callable | None, solvefn: Callable,
-                 side: str = 'left') -> None:
+    def __init__(
+        self, setupfn: Callable | None, solvefn: Callable, side: str = 'left'
+    ) -> None:
         """
         Wrapper for passing preconditioner functions to CVODE. Preconditioning
         is only supported by iterative solvers (gmres, bicgstab, tfqmr).

--- a/src/sksundae/cvode/_solver.py
+++ b/src/sksundae/cvode/_solver.py
@@ -1,12 +1,10 @@
-# cvode._solver.py
-
 from __future__ import annotations
 
 from typing import Callable, Literal, TYPE_CHECKING
 
 from sksundae._cy_cvode import CVODE as _CVODE, CVODEResult as _CVODEResult
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from numpy import ndarray
 
 
@@ -45,7 +43,7 @@ class CVODE:
         atol : float or array_like[float], optional
             Absolute tolerance. A scalar will apply to all variables equally,
             while an array (matching 'y' length) sets specific tolerances for
-            eqch variable. The default is 1e-6.
+            each variable. The default is 1e-6.
         linsolver : {'dense', 'band', 'sparse', ...}, optional
             Choice of linear solver, defaults to 'dense'. 'band' requires both
             'lband' and 'uband'. 'sparse' uses SuperLU_MT [3]_ and requires
@@ -55,10 +53,10 @@ class CVODE:
             'dense' and 'band'. They use OpenBLAS-linked LAPACK [4]_ routines,
             but can have noticeable overhead for small (<100) systems.
         lband : int or None, optional
-            Lower Jacobian bandwidth. Given an ODE system `yp = f(t, y)`,
-            the Jacobian is `J = df_i/dy_j`. Required when 'linsolver' is
-            'band'. Use zero if no values are below the main diagonal. Defaults
-            to None.
+            Lower Jacobian bandwidth. Given a system `yp = f(t, y)`, the
+            Jacobian is `J = df_i/dy_j`. Required if 'linsolver' is 'band'.
+            Use zero if no values are below the main diagonal. The default
+            is None.
         uband : int or None, optional
             Upper Jacobian bandwidth. Required when 'linsolver' is 'band'. Use
             zero if no elements are above the main diagonal. Defaults to None.
@@ -99,8 +97,8 @@ class CVODE:
             If 'constraints_idx' is not None, then this option must include an
             array of equal length specifying the types of constraints to apply.
             Values should be in `{-2, -1, 1, 2}` which apply `y[i] < 0`,
-            `y[i] <= 0`, `y[i] >= 0`, and `y[i] > 0`, respectively. The
-            default is None.
+            `y[i] <= 0`, `y[i] >= 0`, and `y[i] > 0`, respectively. The default
+            is None.
         eventsfn : Callable or None, optional
             Events function with signature `g(t, y, events[, userdata])`.
             If None (default), no events are tracked. See the notes for more
@@ -111,7 +109,7 @@ class CVODE:
                 terminal: list[bool, int], optional
                     Specifies solver behavior for each event. A boolean stops
                     the solver (True) or just records the event (False). An
-                    integer stops the solver after than many occurrences. The
+                    integer stops the solver after that many occurrences. The
                     default is `[True]*num_events`.
                 direction: list[int], optional
                     Determines which event slopes to track: `-1` (negative),
@@ -149,7 +147,7 @@ class CVODE:
         than overwriting it. For example, using `yp[:] = f(t, y)` is correct
         whereas `yp = f(t, y)` is not.
 
-        When any user-defined function require data outside of their normal
+        When any user-defined function requires data outside of their normal
         arguments, you can supply optional 'userdata'. When given, 'userdata'
         must appear in ALL function signatures ('rhsfn', 'eventsfn', 'jacfn',
         'precond', and 'jactimes') even if it is not used in all functions. Of
@@ -302,8 +300,12 @@ class CVODE:
         """
         return self.__CVODE.init_step(t0, y0)
 
-    def step(self, t: float, method: Literal['normal', 'onestep'] = 'normal',
-             tstop: float | None = None) -> CVODEResult:
+    def step(
+        self,
+        t: float,
+        method: Literal['normal', 'onestep'] = 'normal',
+        tstop: float | None = None,
+    ) -> CVODEResult:
         """
         Return the solution at time 't'.
 

--- a/src/sksundae/ida/__init__.py
+++ b/src/sksundae/ida/__init__.py
@@ -5,9 +5,9 @@ and iterative linear solvers, root finding, and more.
 
 """
 
-from ._solver import IDA, IDAResult
 from ._precond import IDAPrecond
 from ._jactimes import IDAJacTimes
+from ._solver import IDA, IDAResult
 
 __all__ = [
     'IDA',

--- a/src/sksundae/ida/_jactimes.py
+++ b/src/sksundae/ida/_jactimes.py
@@ -1,6 +1,5 @@
-# ida._jactimes.py
-
 from __future__ import annotations
+
 from typing import Callable
 
 

--- a/src/sksundae/ida/_precond.py
+++ b/src/sksundae/ida/_precond.py
@@ -1,6 +1,5 @@
-# ida._precond.py
-
 from __future__ import annotations
+
 from typing import Callable
 
 

--- a/src/sksundae/ida/_solver.py
+++ b/src/sksundae/ida/_solver.py
@@ -1,12 +1,10 @@
-# ida._solver.py
-
 from __future__ import annotations
 
 from typing import Callable, Literal, TYPE_CHECKING
 
 from sksundae._cy_ida import IDA as _IDA, IDAResult as _IDAResult
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from numpy import ndarray
 
 
@@ -16,8 +14,8 @@ class IDA:
     def __init__(self, resfn: Callable, **options) -> None:
         """
         A class to wrap the implicit differential algebraic (IDA) solver from
-        SUNDIALS [1]_ [2]_. IDA solves both ordinary differential equations
-        (ODEs) and differiential agebraic equations (DAEs).
+        SUNDIALS [1]_ [2]_. IDA solves both implicit ordinary differential
+        equations (ODEs) and differential algebraic equations (DAEs).
 
         Parameters
         ----------
@@ -52,7 +50,7 @@ class IDA:
         atol : float or array_like[float], optional
             Absolute tolerance. A scalar will apply to all variables equally,
             while an array (matching 'y' length) sets specific tolerances for
-            eqch variable. The default is 1e-6.
+            each variable. The default is 1e-6.
         linsolver : {'dense', 'band', 'sparse', ...}, optional
             Choice of linear solver, defaults to 'dense'. 'band' requires both
             'lband' and 'uband'. 'sparse' uses SuperLU_MT [3]_ and requires
@@ -62,10 +60,10 @@ class IDA:
             'dense' and 'band'. They use OpenBLAS-linked LAPACK [4]_ routines,
             but can have noticeable overhead for small (<100) systems.
         lband : int or None, optional
-            Lower Jacobian bandwidth. Given a DAE system `0 = F(t, y, yp)`,
-            the Jacobian is `J = dF_i/dy_j + cj*dF_i/dyp_j`. Required when
-            'linsolver' is 'band'. Use zero if no values are below the main
-            diagonal. Defaults to None.
+            Lower Jacobian bandwidth. Given a system `0 = F(t, y, yp)`, the
+            Jacobian is `J = dF_i/dy_j + cj*dF_i/dyp_j`. Required if 'linsolver'
+            is 'band'. Use zero if no values are below the main diagonal. The
+            default is None.
         uband : int or None, optional
             Upper Jacobian bandwidth. Required when 'linsolver' is 'band'. Use
             zero if no elements are above the main diagonal. Defaults to None.
@@ -105,8 +103,8 @@ class IDA:
             If 'constraints_idx' is not None, then this option must include an
             array of equal length specifying the types of constraints to apply.
             Values should be in `{-2, -1, 1, 2}` which apply `y[i] < 0`,
-            `y[i] <= 0`, `y[i] >= 0`, and `y[i] > 0`, respectively. The
-            default is None.
+            `y[i] <= 0`, `y[i] >= 0`, and `y[i] > 0`, respectively. The default
+            is None.
         eventsfn : Callable or None, optional
             Events function with signature `g(t, y, yp, events[, userdata])`.
             If None (default), no events are tracked. See the notes for more
@@ -117,7 +115,7 @@ class IDA:
                 terminal: list[bool, int], optional
                     Specifies solver behavior for each event. A boolean stops
                     the solver (True) or just records the event (False). An
-                    integer stops the solver after than many occurrences. The
+                    integer stops the solver after that many occurrences. The
                     default is `[True]*num_events`.
                 direction: list[int], optional
                     Determines which event slopes to track: `-1` (negative),
@@ -156,7 +154,7 @@ class IDA:
         than overwriting it. For example, using `res[:] = F(t, y, yp)` is
         correct whereas `res = F(t, y, yp)` is not.
 
-        When any user-defined function require data outside of their normal
+        When any user-defined function requires data outside of their normal
         arguments, you can supply optional 'userdata'. When given, 'userdata'
         must appear in ALL function signatures ('rhsfn', 'eventsfn', 'jacfn',
         'precond', and 'jactimes') even if it is not used in all functions. Of
@@ -326,8 +324,12 @@ class IDA:
         """
         return self.__IDA.init_step(t0, y0, yp0)
 
-    def step(self, t: float, method: Literal['normal', 'onestep'] = 'normal',
-             tstop: float | None = None) -> IDAResult:
+    def step(
+        self,
+        t: float,
+        method: Literal['normal', 'onestep'] = 'normal',
+        tstop: float | None = None,
+    ) -> IDAResult:
         """
         Return the solution at time 't'.
 

--- a/src/sksundae/jacband.py
+++ b/src/sksundae/jacband.py
@@ -6,32 +6,41 @@ pattern and/or bandwidth.
 """
 
 from __future__ import annotations
+
 from typing import Callable, Any, TYPE_CHECKING
 
 import inspect
+
 from warnings import warn
 
 import numpy as np
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from numpy.typing import ndarray
     from scipy.sparse import spmatrix
 
 
-def _cvode_pattern(rhsfn: Callable, t0: float, y0: ndarray,
-                   userdata: Any = None) -> ndarray:
+def _cvode_pattern(
+    rhsfn: Callable, t0: float, y0: ndarray, userdata: Any = None
+) -> ndarray:
     """Jacobian pattern for CVODE functions. Access via j_pattern()."""
     # wrap rhsfn for cases w/ and w/o userdata
     signature = inspect.signature(rhsfn)
 
     if len(signature.parameters) == 3:
-        def wrapper(t, y, yp): return rhsfn(t, y, yp)
+
+        def wrapper(t, y, yp):
+            return rhsfn(t, y, yp)
+
     elif len(signature.parameters) == 4:
         if userdata is None:
-            warn("'rhsfn' signature has 4 inputs so 'userdata' is expected,"
-                 " but 'userdata=None'. Ensure this was intentional.")
+            warn(
+                "'rhsfn' signature has 4 inputs so 'userdata' is expected,"
+                " but 'userdata=None'. Ensure this was intentional."
+            )
 
-        def wrapper(t, y, yp): return rhsfn(t, y, yp, userdata)
+        def wrapper(t, y, yp):
+            return rhsfn(t, y, yp, userdata)
     else:
         raise ValueError("'rhsfn' signature must have either 3 or 4 inputs.")
 
@@ -72,20 +81,31 @@ def _cvode_pattern(rhsfn: Callable, t0: float, y0: ndarray,
     return np.column_stack(j_cols)
 
 
-def _ida_pattern(resfn: Callable, t0: float, y0: ndarray, yp0: ndarray = None,
-                 userdata: Any = None) -> ndarray:
+def _ida_pattern(
+    resfn: Callable,
+    t0: float,
+    y0: ndarray,
+    yp0: ndarray = None,
+    userdata: Any = None,
+) -> ndarray:
     """Jacobian pattern for IDA functions. Access via j_pattern()."""
     # wrap resfn for cases w/ and w/o userdata
     signature = inspect.signature(resfn)
 
     if len(signature.parameters) == 4:
-        def wrapper(t, y, yp, res): return resfn(t, y, yp, res)
+
+        def wrapper(t, y, yp, res):
+            return resfn(t, y, yp, res)
+
     elif len(signature.parameters) == 5:
         if userdata is None:
-            warn("'rhsfn' signature has 5 inputs so 'userdata' is expected,"
-                 " but 'userdata=None'. Ensure this was intentional.")
+            warn(
+                "'rhsfn' signature has 5 inputs so 'userdata' is expected,"
+                " but 'userdata=None'. Ensure this was intentional."
+            )
 
-        def wrapper(t, y, yp, res): return resfn(t, y, yp, res, userdata)
+        def wrapper(t, y, yp, res):
+            return resfn(t, y, yp, res, userdata)
     else:
         raise ValueError("'rhsfn' signature must have either 4 or 5 inputs.")
 
@@ -133,8 +153,13 @@ def _ida_pattern(resfn: Callable, t0: float, y0: ndarray, yp0: ndarray = None,
     return np.column_stack(j_cols)
 
 
-def j_pattern(rhsfn: Callable, t0: float, y0: ndarray, yp0: ndarray = None,
-              userdata: Any = None) -> ndarray:
+def j_pattern(
+    rhsfn: Callable,
+    t0: float,
+    y0: ndarray,
+    yp0: ndarray = None,
+    userdata: Any = None,
+) -> ndarray:
     """
     Approximate the Jacobian pattern.
 
@@ -204,11 +229,13 @@ def bandwidth(A: ndarray) -> tuple[int]:
 
     """
     from scipy.linalg import bandwidth
+
     return bandwidth(A)
 
 
-def reduce_bandwidth(A: ndarray | spmatrix,
-                     symmetric: bool = False) -> tuple[ndarray]:
+def reduce_bandwidth(
+    A: ndarray | spmatrix, symmetric: bool = False
+) -> tuple[ndarray]:
     """
     Find a row/col reordering to reduce bandwidth.
 

--- a/src/sksundae/utils/_timer.py
+++ b/src/sksundae/utils/_timer.py
@@ -79,15 +79,15 @@ class Timer:
         self._units = units
         self._converter = {
             's': lambda t: t,
-            'min': lambda t: t / 60.,
-            'h': lambda t: t / 3600.,
+            'min': lambda t: t / 60.0,
+            'h': lambda t: t / 3600.0,
         }
 
-        self._start = 0.
-        self._stop = 0.
+        self._start = 0.0
+        self._stop = 0.0
         self._display = display
 
-    def __repr__(self) -> str:  # pragma: no cover
+    def __repr__(self) -> str:
         """Quick representation of the timer showing name, time, and units."""
         elapsed = self._converter[self._units](self.elapsed_time)
         elapsed_string = f"{elapsed} {self._units}"


### PR DESCRIPTION
# Description
Fixed a couple typos in the solver docstrings (CVODE and IDA). Also did some general clean up for sorting import statements and removing `# pragma: no cover` statements for `TYPE_CHECKING` and `__repr__` in favor of global rule in `pyproject.toml`. Lastly, changed name of `ci.yml` workflow so badges fit the screen better on mobile.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (any other clean up, maintenance, etc.)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.