### PR TITLE
chore/prep-py315

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.11", "3.14", "3.15.0rc1"]  # Oct 2026: "3.15"
+        python-version: ["3.11", "3.14"]  # Oct 2026: "3.15"
         
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.11", "3.14", "3.15.0-rc.1"]  # Oct 2026: "3.15"
+        python-version: ["3.11", "3.14", "3.15.0rc1"]  # Oct 2026: "3.15"
         
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.14"]
+        python-version: ["3.14"]  # Oct 2026: "3.15"
 
     steps:
       - name: Checkout repository
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14", "3.15.0-rc.1"]  # Oct 2026: "3.15"
         
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.15"
 
       - name: Extract tag version details
         id: tag
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.15"
 
       - name: Check version details against PyPI, tag, etc.
         run: |
@@ -96,7 +96,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v3
         with:  # ci_environment.yml specifies sundials version to compile
           environment-file: environments/ci_environment.yml
-          create-args: python=3.14
+          create-args: python=3.15
 
       - name: List info
         if: runner.os != 'Linux'
@@ -155,7 +155,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.14"]
+        python-version: ["3.15"]
 
     defaults:
       run:
@@ -217,7 +217,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.15"
 
       - name: Install twine
         run: pip install twine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/NatLabRockies/scikit-sundae)
 
 ### New Features
-- Allow builds against newest SUNDIALS v7.9, use in CI/RTD workflows ([#56](https://github.com/NatLabRockies/scikit-sundae/pull/54))
+- Allow builds against newest SUNDIALS v7.9, use in CI/RTD workflows ([#56](https://github.com/NatLabRockies/scikit-sundae/pull/56))
 - Move to newest SUNDIALS v7.8 for CI builds/tests ([#54](https://github.com/NatLabRockies/scikit-sundae/pull/54))
 - Add `Timer` and `Timeout` utils to profile and limit execution times ([#53](https://github.com/NatLabRockies/scikit-sundae/pull/53))
 - Move to newest SUNDIALS v7.7 for CI builds/tests ([#52](https://github.com/NatLabRockies/scikit-sundae/pull/52))
@@ -14,12 +14,13 @@
 None.
 
 ### Bug Fixes
+- Namespace overlap for `TimeoutError` fixed by rename to `TimeoutExpiredError` ([#57](https://github.com/NatLabRockies/scikit-sundae/pull/57))
 - Address memory leak with raised exceptions caused by persisting solver/data objects ([#51](https://github.com/NatLabRockies/scikit-sundae/pull/51))
 - Fixes issue where `jacfn` is ignored when using `sparse` linear solver ([#48](https://github.com/NatLabRockies/scikit-sundae/pull/48))
 - Ensures exception propagations work correctly with numpy 2.4 release ([#41](https://github.com/NatLabRockies/scikit-sundae/pull/41))
 
 ### Breaking Changes
-None.
+- Drop support for Python 3.10, reaches end of life in October 2026 ([#57](https://github.com/NatLabRockies/scikit-sundae/pull/57))
 
 ### Chores
 - Fix typos in solver docstrings, use global coverage ignores in `pyproject.toml` ([#55](https://github.com/NatLabRockies/scikit-sundae/pull/55))

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -1,7 +1,7 @@
 name: sun
 channels:
-  - conda-forge
   - conda-forge/label/python_dev
+  - conda-forge
 dependencies:
   - sundials=7.8
   - libblas=*=*openblas

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -1,6 +1,5 @@
 name: sun
 channels:
-  - conda-forge/label/python_rc
   - conda-forge
 dependencies:
   - sundials=7.8

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -1,6 +1,7 @@
 name: sun
 channels:
   - conda-forge
+  - conda-forge/label/python_dev
 dependencies:
   - sundials=7.8
   - libblas=*=*openblas

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -1,6 +1,6 @@
 name: sun
 channels:
-  - conda-forge/label/python_dev
+  - conda-forge/label/python_rc
   - conda-forge
 dependencies:
   - sundials=7.8

--- a/environments/rtd_environment.yml
+++ b/environments/rtd_environment.yml
@@ -2,7 +2,7 @@ name: sun
 channels:
   - conda-forge
 dependencies:
-  - python=3.14
+  - python=3.14  # Oct 2026: 3.15
   - sundials=7.8
   - libblas=*=*openblas
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scikit-sundae"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.11,<3.16"
 license = "BSD-3-Clause"
 license-files = ["LICENSE*"]
 description = "Python bindings to SUNDIALS differential algebraic equation solvers."
@@ -24,11 +24,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 dependencies = ["numpy", "scipy"]
 

--- a/src/sksundae/utils/_timeout.py
+++ b/src/sksundae/utils/_timeout.py
@@ -4,7 +4,7 @@ import _thread
 import threading
 
 
-class TimeoutError(BaseException):
+class TimeoutExpiredError(BaseException):
     pass
 
 
@@ -12,7 +12,12 @@ class Timeout:
     """Timeout context manager."""
 
     __slots__ = (
-        '_seconds', '_name', '_raise_exc', '_timer', '_expired', '_exception',
+        '_seconds',
+        '_name',
+        '_raise_exc',
+        '_timer',
+        '_expired',
+        '_exception',
     )
 
     def __init__(
@@ -23,9 +28,9 @@ class Timeout:
     ) -> None:
         """
         Uses a thread to track the time spent in a context block and forces an
-        exit (and optionally raises a `TimeoutError`) if the execution time
-        exceeds a given number of seconds. See the notes for important details
-        on edge cases where this may not work as expected.
+        exit (and optionally raises a `TimeoutExpiredError`) if the execution
+        time exceeds a given number of seconds. See the notes for important
+        details on edge cases where this may not work as expected.
 
         Parameters
         ----------
@@ -34,8 +39,8 @@ class Timeout:
         name : str, optional
             Name to identify the block in exit messages, by default 'Timeout'.
         raise_exc : bool, optional
-            If True, raise a `TimeoutError` on exit when the given time limit is
-            exceeded. Use False to handle the timeout manually.
+            If True, raise a `TimeoutExpiredError` on exit when the given time
+            limit is exceeded. Use False to handle the timeout manually.
 
         Notes
         -----
@@ -119,7 +124,7 @@ class Timeout:
 
         self._timer = None
         self._expired = False
-        self._exception = TimeoutError(
+        self._exception = TimeoutExpiredError(
             f"{self._name} exceeded {self._seconds:.2f} seconds."
         )
 
@@ -151,7 +156,7 @@ class Timeout:
         return self._expired
 
     @property
-    def exception(self) -> TimeoutError:
+    def exception(self) -> TimeoutExpiredError:
         """The exception to raise if the timer expired."""
         return self._exception
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ def test_rich_result():
     assert repr(result) == 'NewResult()'
 
     class OrderedResult(sun.utils.RichResult):
-        _order_keys = ['first', 'second',]
+        _order_keys = ['first', 'second']
 
     new = NewResult(second=None, first=None)
     ordered = OrderedResult(second=None, first=None)
@@ -57,47 +57,47 @@ def test_timer():
     # basic
     def f():
         time.sleep(1e-3)
-        return 0.
+        return 0.0
 
     with sun.utils.Timer('success') as timer:
         _ = f()
 
     assert timer.name == 'success'
-    assert timer.elapsed_time >= 0.
-    assert timer._converter['s'](3600.) == 3600.
-    assert timer._converter['min'](3600.) == 60.
-    assert timer._converter['h'](3600.) == 1.
+    assert timer.elapsed_time >= 0.0
+    assert timer._converter['s'](3600.0) == 3600.0
+    assert timer._converter['min'](3600.0) == 60.0
+    assert timer._converter['h'](3600.0) == 1.0
 
 
 def test_timeout():
 
     # initialization
     timeout = sun.utils.Timeout(1, name='TestTimeout', raise_exc=False)
-    TimeoutError = type(timeout.exception)
+    TimeoutExpiredError = type(timeout.exception)
 
-    assert type(timeout.exception).__name__ == 'TimeoutError'
+    assert type(timeout.exception).__name__ == 'TimeoutExpiredError'
     assert str(timeout.exception) == 'TestTimeout exceeded 1.00 seconds.'
 
     # does not expire
-    with sun.utils.Timeout(0.1, name='NoExpire') as timeout:
-        time.sleep(0.001)
+    with sun.utils.Timeout(0.5, name='NoExpire') as timeout:
+        time.sleep(0.01)
 
     assert timeout.expired is False
 
     # expires and raises exception
-    with pytest.raises(TimeoutError, match='Timeout exceeded'):
-        with sun.utils.Timeout(0.001):
-            time.sleep(0.1)
+    with pytest.raises(TimeoutExpiredError, match='Timeout exceeded'):
+        with sun.utils.Timeout(0.05):
+            time.sleep(0.2)
 
     # expires but does not raise exception
-    with sun.utils.Timeout(0.001, raise_exc=False) as timeout:
-        time.sleep(0.1)
+    with sun.utils.Timeout(0.05, raise_exc=False) as timeout:
+        time.sleep(0.2)
 
     assert timeout.expired is True
 
     # differentiate user interruptions
     with pytest.raises(KeyboardInterrupt):
-        with sun.utils.Timeout(1.0, raise_exc=False) as timeout:
+        with sun.utils.Timeout(10.0, raise_exc=False) as timeout:
             raise KeyboardInterrupt
 
     assert timeout.expired is False


### PR DESCRIPTION
# Description
Drop support for Python 3.10 and prep for supporting Python 3.15. Also, fix namespace overlap with `TimeoutError` from standard library, now renamed to `TimeoutExpiredError`.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (any other clean up, maintenance, etc.)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.